### PR TITLE
(fix) Allow user to change origin if out of bounds

### DIFF
--- a/client/src/components/App/App.jsx
+++ b/client/src/components/App/App.jsx
@@ -128,7 +128,6 @@ const App = (props) => {
     } else {
       flashMessage.flashText('Bummer dude... There was an error getting your directions', 5);
     }
-    appHelper.cancelRouting(props);
   };
 
   return (


### PR DESCRIPTION
If user's current location (or a selected origin) is out of bounds, this allows the user to change the origin to something that is in bounds.

Previously, origin was cleared, then the user is taken back to the "VIEWING_MAP" view so the user did not have an opportunity to change the origin.